### PR TITLE
Fix GENESIS-v2 training on multiple GPUs

### DIFF
--- a/models/genesisv2_config.py
+++ b/models/genesisv2_config.py
@@ -58,6 +58,7 @@ class GenesisV2(nn.Module):
         self.detach_mr_in_klm = cfg.detach_mr_in_klm
         self.dynamic_K = cfg.dynamic_K
         self.debug = cfg.debug
+        self.multi_gpu = cfg.multi_gpu
         # Encoder
         self.encoder = UNet(
             num_blocks=int(np.log2(cfg.img_size)-1),
@@ -193,6 +194,11 @@ class GenesisV2(nn.Module):
                 assert len(log_m_r_k) == self.K_steps
             misc.check_log_masks(log_m_k)
             misc.check_log_masks(log_m_r_k)
+
+        if self.multi_gpu:
+            # q_z_k is a torch.distribution which doesn't work with the
+            # gathering used by DataParallel.
+            del comp_stats['q_z_k']
 
         return recon, losses, stats, att_stats, comp_stats
 

--- a/modules/blocks.py
+++ b/modules/blocks.py
@@ -175,4 +175,4 @@ class SemiConv(nn.Module):
     def forward(self, x):
         out = self.gate(self.conv(x))
         delta = out[:, -2:, :, :]
-        return out + self.uv, delta
+        return out + self.uv.to(out.device), delta

--- a/train.py
+++ b/train.py
@@ -190,7 +190,8 @@ def main():
         # Remove unnecessary items for backwards compatibility with older models
         model_state_dict.pop('comp_vae.decoder_module.seq.0.pixel_coords.g_1', None)
         model_state_dict.pop('comp_vae.decoder_module.seq.0.pixel_coords.g_2', None)
-        model.load_state_dict(model_state_dict)
+        load_model = model.module if config.gpu and config.multi_gpu else model
+        load_model.load_state_dict(model_state_dict)
         # Restore optimiser
         optimiser.load_state_dict(checkpoint['optimiser_state_dict'])
         # Optional: Restore GECO
@@ -351,7 +352,8 @@ def main():
             
             # Visualise model outputs
             if iter_idx % config.log_images_every == 0:
-                visualise_outputs(model, train_batch, writer, 'train', iter_idx)
+                vis_model = model.module if config.gpu and config.multi_gpu else model
+                visualise_outputs(vis_model, train_batch, writer, 'train', iter_idx)
                 fprint("Logged images to TensorBoard")
 
             # Increment counter


### PR DESCRIPTION
As promised per mail here's a PR with the changes I made in order to train GENESIS-v2 on multiple GPUs.

I tested the changes by training on Multi-dSprites, including continuing from a previous checkpoint. PyTorch outputs a warning (see below), but training works well and I didn't run into memory issues.

```
UserWarning: RNN module weights are not part of single contiguous chunk of memory. This means they need to be compacted at every call, possibly greatly increasing memory usage. To compact weights again call flatten_parameters().
```
